### PR TITLE
Fix JWT test cmake error

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,8 +134,7 @@ target_link_libraries(opcua_test neuron-base gtest_main gtest yaml jansson ssl c
 
 file(COPY ${CMAKE_SOURCE_DIR}/private_test.key DESTINATION ${CMAKE_BINARY_DIR}/tests)
 file(COPY ${CMAKE_SOURCE_DIR}/public_test.pem DESTINATION ${CMAKE_BINARY_DIR}/tests)
-add_executable(jwt_test jwt_test.cc 
-    ${CMAKE_SOURCE_DIR}/src/utils/neu_jwt.c)
+add_executable(jwt_test jwt_test.cc)
 target_include_directories(jwt_test PRIVATE 
     ${CMAKE_SOURCE_DIR}/src 
 	${CMAKE_SOURCE_DIR}/include


### PR DESCRIPTION
Fix the address sanitizer report an `odr-violation` of `pub_key_len` in file `src/utils/neu_jwt.c`.