### PR TITLE
confirm the length of the group name to avoid program exceptions

### DIFF
--- a/plugins/restful/datatag_handle.c
+++ b/plugins/restful/datatag_handle.c
@@ -38,7 +38,7 @@ void handle_add_tags(nng_aio *aio)
         aio, neu_json_add_tags_req_t, neu_json_decode_add_tags_req, {
             if (strlen(req->group) >= NEU_GROUP_NAME_LEN) {
                 NEU_JSON_RESPONSE_ERROR(NEU_ERR_GROUP_NAME_TOO_LONG, {
-                    http_response(aio, NEU_ERR_GROUP_NAME_TOO_LONG,
+                    neu_http_response(aio, NEU_ERR_GROUP_NAME_TOO_LONG,
                                   result_error);
                 });
             } else {


### PR DESCRIPTION
- confirm the length of the group name to avoid program exceptions caused by the group name exceeding the length when directly inserting tags
- using hneu_http_response