### PR TITLE
Pick to 2.4 feat(mqtt): make offline cache setting more explicit

### DIFF
--- a/plugins/mqtt/mqtt.json
+++ b/plugins/mqtt/mqtt.json
@@ -57,6 +57,16 @@
       ]
     }
   },
+  "offline-cache": {
+    "name": "Offline Data Caching",
+    "name_zh": "离线缓存",
+    "description": "Offline caching switch. Cache MQTT messages when offline, and sync cached messages when back online.",
+    "description_zh": "离线缓存开关。连接断开时缓存 MQTT 消息，连接重建时同步缓存的 MQTT 消息到服务器。",
+    "attribute": "optional",
+    "type": "bool",
+    "default": false,
+    "valid": {}
+  },
   "cache-mem-size": {
     "name": "Cache Memory Size (MB)",
     "name_zh": "缓存内存大小（MB）",
@@ -64,9 +74,12 @@
     "description_zh": "当 MQTT 连接异常时，最大的内存缓存大小（单位：MB）。应该小于缓存磁盘大小。",
     "type": "int",
     "attribute": "required",
-    "default": 0,
+    "condition": {
+      "field": "offline-cache",
+      "value": true
+    },
     "valid": {
-      "min": 0,
+      "min": 1,
       "max": 1024
     }
   },
@@ -77,9 +90,12 @@
     "description_zh": "当 MQTT 连接异常时，最大的磁盘缓存大小（单位：MB）。应该大于缓存内存大小。如果不为 0，缓存内存大小也应该不为 0。",
     "type": "int",
     "attribute": "required",
-    "default": 0,
+    "condition": {
+      "field": "offline-cache",
+      "value": true
+    },
     "valid": {
-      "min": 0,
+      "min": 1,
       "max": 10240
     }
   },


### PR DESCRIPTION
  1. Add `offline-cache` bool parameter.
  2. Require `cache-mem-size` and `cache-disk-size` only when `offline-cache` is enabled. We provide no defaults for `cache-mem-size` and `cache-disk-size`, so the user must provide values explicitly.