### PR TITLE
feat: add FC 0x06 compatibility to modbus plugins and simulator

### DIFF
--- a/plugins/modbus/modbus.h
+++ b/plugins/modbus/modbus.h
@@ -35,7 +35,7 @@
 /* big-endian order */
 
 typedef enum modbus_action {
-    MODBUS_ACTION_DEFAULT  = 0,
+    MODBUS_ACTION_DEFAULT        = 0,
     MODBUS_ACTION_HOLD_REG_WRITE = 1
 } modbus_action_e;
 

--- a/plugins/modbus/modbus.h
+++ b/plugins/modbus/modbus.h
@@ -34,6 +34,11 @@
 
 /* big-endian order */
 
+typedef enum modbus_action {
+    MODBUS_ACTION_DEFAULT  = 0,
+    MODBUS_ACTION_HOLD_REG_WRITE = 1
+} modbus_action_e;
+
 typedef enum modbus_function {
     MODBUS_READ_COIL        = 0x1,
     MODBUS_READ_INPUT       = 0x02,
@@ -78,7 +83,7 @@ struct modbus_address {
 } __attribute__((packed));
 
 void modbus_address_wrap(neu_protocol_pack_buf_t *buf, uint16_t start,
-                         uint16_t n_register);
+                         uint16_t n_register, enum modbus_action m_action);
 int  modbus_address_unwrap(neu_protocol_unpack_buf_t *buf,
                            struct modbus_address *    out_address);
 
@@ -88,7 +93,7 @@ struct modbus_data {
 } __attribute__((packed));
 
 void modbus_data_wrap(neu_protocol_pack_buf_t *buf, uint8_t n_byte,
-                      uint8_t *bytes);
+                      uint8_t *bytes, enum modbus_action action);
 int  modbus_data_unwrap(neu_protocol_unpack_buf_t *buf,
                         struct modbus_data *       out_data);
 

--- a/plugins/modbus/modbus_stack.c
+++ b/plugins/modbus/modbus_stack.c
@@ -141,13 +141,14 @@ int modbus_stack_read(modbus_stack_t *stack, uint8_t slave_id,
     static __thread uint8_t                 buf[16] = { 0 };
     static __thread neu_protocol_pack_buf_t pbuf    = { 0 };
     int                                     ret     = 0;
+    modbus_action_e                         m_action = MODBUS_ACTION_DEFAULT;
 
     neu_protocol_pack_buf_init(&pbuf, buf, sizeof(buf));
 
     if (stack->protocol == MODBUS_PROTOCOL_RTU) {
         modbus_crc_wrap(&pbuf);
     }
-    modbus_address_wrap(&pbuf, start_address, n_reg);
+    modbus_address_wrap(&pbuf, start_address, n_reg, m_action);
 
     switch (area) {
     case MODBUS_AREA_COIL:
@@ -197,6 +198,7 @@ int modbus_stack_write(modbus_stack_t *stack, void *req, uint8_t slave_id,
                        uint16_t *response_size)
 {
     static __thread neu_protocol_pack_buf_t pbuf = { 0 };
+    modbus_action_e                         m_action = MODBUS_ACTION_DEFAULT;
 
     memset(stack->buf, 0, stack->buf_size);
     neu_protocol_pack_buf_init(&pbuf, stack->buf, stack->buf_size);
@@ -208,16 +210,20 @@ int modbus_stack_write(modbus_stack_t *stack, void *req, uint8_t slave_id,
     switch (area) {
     case MODBUS_AREA_COIL:
         if (*bytes > 0) {
-            modbus_address_wrap(&pbuf, start_address, 0xff00);
+            modbus_address_wrap(&pbuf, start_address, 0xff00,
+                                m_action);
         } else {
-            modbus_address_wrap(&pbuf, start_address, 0);
+            modbus_address_wrap(&pbuf, start_address, 0, m_action);
         }
         modbus_code_wrap(&pbuf, slave_id, MODBUS_WRITE_S_COIL);
         break;
     case MODBUS_AREA_HOLD_REGISTER:
-        modbus_data_wrap(&pbuf, n_byte, bytes);
-        modbus_address_wrap(&pbuf, start_address, n_reg);
-        modbus_code_wrap(&pbuf, slave_id, MODBUS_WRITE_M_HOLD_REG);
+        m_action = MODBUS_ACTION_HOLD_REG_WRITE;
+        modbus_data_wrap(&pbuf, n_byte, bytes, m_action);
+        modbus_address_wrap(&pbuf, start_address, n_reg, m_action);
+        modbus_code_wrap(&pbuf, slave_id,
+                         n_reg > 1 ? MODBUS_WRITE_M_HOLD_REG
+                                   : MODBUS_WRITE_S_HOLD_REG);
         break;
     default:
         stack->write_resp(stack->ctx, req, NEU_ERR_PLUGIN_TAG_NOT_ALLOW_WRITE);

--- a/plugins/modbus/modbus_stack.c
+++ b/plugins/modbus/modbus_stack.c
@@ -138,9 +138,9 @@ int modbus_stack_read(modbus_stack_t *stack, uint8_t slave_id,
                       enum modbus_area area, uint16_t start_address,
                       uint16_t n_reg, uint16_t *response_size)
 {
-    static __thread uint8_t                 buf[16] = { 0 };
-    static __thread neu_protocol_pack_buf_t pbuf    = { 0 };
-    int                                     ret     = 0;
+    static __thread uint8_t                 buf[16]  = { 0 };
+    static __thread neu_protocol_pack_buf_t pbuf     = { 0 };
+    int                                     ret      = 0;
     modbus_action_e                         m_action = MODBUS_ACTION_DEFAULT;
 
     neu_protocol_pack_buf_init(&pbuf, buf, sizeof(buf));
@@ -197,7 +197,7 @@ int modbus_stack_write(modbus_stack_t *stack, void *req, uint8_t slave_id,
                        uint16_t n_reg, uint8_t *bytes, uint8_t n_byte,
                        uint16_t *response_size)
 {
-    static __thread neu_protocol_pack_buf_t pbuf = { 0 };
+    static __thread neu_protocol_pack_buf_t pbuf     = { 0 };
     modbus_action_e                         m_action = MODBUS_ACTION_DEFAULT;
 
     memset(stack->buf, 0, stack->buf_size);
@@ -210,8 +210,7 @@ int modbus_stack_write(modbus_stack_t *stack, void *req, uint8_t slave_id,
     switch (area) {
     case MODBUS_AREA_COIL:
         if (*bytes > 0) {
-            modbus_address_wrap(&pbuf, start_address, 0xff00,
-                                m_action);
+            modbus_address_wrap(&pbuf, start_address, 0xff00, m_action);
         } else {
             modbus_address_wrap(&pbuf, start_address, 0, m_action);
         }


### PR DESCRIPTION
Partially Closes emqx/neuron#1175
Good evening, this PR adds compatibility for Function Code 0x06 (write single holding register) as there are some devices that do not support setting registers via FC 0x10 (write multiple registers).

Built-in functional tests for writing holding register with int16 and uint16 values already cover this change, I can adjust the description of relevant keywords and submit another PR if needed.

I'm fairly new to C and collaborating on github in general, sorry if I missed anything.
Regarding functionality, the PR was tested on hardware communicating via ModbusTCP for about a week now, Modbus RTU was tested on synthetic tests, so far everything works as expected.
All FT and unit tests: PASS

Have a great day and all the best,
ev
