### PR TITLE
[main]fix: write tags api int->double type

### DIFF
--- a/plugins/restful/rw_handle.c
+++ b/plugins/restful/rw_handle.c
@@ -174,7 +174,7 @@ void handle_write_tags(nng_aio *aio)
                 switch (req->tags[i].t) {
                 case NEU_JSON_INT:
                     cmd.tags[i].value.type      = NEU_TYPE_INT64;
-                    cmd.tags[i].value.value.u64 = req->tags[i].value.val_int;
+                    cmd.tags[i].value.value.i64 = req->tags[i].value.val_int;
                     break;
                 case NEU_JSON_STR:
                     cmd.tags[i].value.type = NEU_TYPE_STRING;

--- a/src/adapter/driver/driver.c
+++ b/src/adapter/driver/driver.c
@@ -637,7 +637,8 @@ void neu_adapter_driver_write_tags(neu_adapter_driver_t *driver,
         neu_datatag_t *tag = neu_group_find_tag(g->group, cmd->tags[i].tag);
         if (tag != NULL && neu_tag_attribute_test(tag, NEU_ATTRIBUTE_WRITE) &&
             neu_tag_attribute_test(tag, NEU_ATTRIBUTE_STATIC) == false) {
-            tv.tag = neu_tag_dup(tag);
+            tv.tag   = neu_tag_dup(tag);
+            tv.value = cmd->tags[i].value.value;
 
             if (tag->type == NEU_TYPE_FLOAT || tag->type == NEU_TYPE_DOUBLE) {
                 if (cmd->tags[i].value.type == NEU_TYPE_INT64) {
@@ -650,7 +651,6 @@ void neu_adapter_driver_write_tags(neu_adapter_driver_t *driver,
             }
             fix_value(tag, cmd->tags[i].value.type, &cmd->tags[i].value);
 
-            tv.value = cmd->tags[i].value.value;
             utarray_push_back(tags, &tv);
         }
         if (tag != NULL) {


### PR DESCRIPTION
/api/v2/write/tags

``` json
{
    "node": "opcua",
    "group": "test",
    "tags": [
        {
            "tag": "LimitSpeed",
            "value": 123
        },
        {
            "tag": "LimitSpeed1",
            "value": 124
        }
    ]
}
```

![image](https://github.com/emqx/neuron/assets/8831188/c1abc58f-91c3-4671-9fbc-2a83ed831ebc)
