### PR TITLE
2.8.1 fix global_timestamp: symbol not found on loading libplugin-mqtt.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(PERSIST_SOURCES
     src/persist/json/persist_json_plugin.c)
 aux_source_directory(src/parser NEURON_SRC_PARSE)
 set(NEURON_BASE_SOURCES
+    src/base/base.c
     src/base/tag.c
     src/base/neu_plugin_common.c
     src/base/tag_sort.c

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -1,3 +1,3 @@
 #include <stdint.h>
 
-int64_t global_timestamp = 0; // move global_timestamp to libneuron_base.so
+int64_t global_timestamp = 0;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -1,0 +1,3 @@
+#include <stdint.h>
+
+int64_t global_timestamp = 0; // move global_timestamp to libneuron_base.so

--- a/src/main.c
+++ b/src/main.c
@@ -42,7 +42,6 @@ bool                  disable_jwt       = false;
 int                   default_log_level = ZLOG_LEVEL_NOTICE;
 char                  host_port[32]     = { 0 };
 
-int64_t global_timestamp = 0;
 
 struct {
     struct sockaddr_in addr;


### PR DESCRIPTION
In `openwrt`, after compiling `neuron` and running it, an error occurred when loading `libplugin-mqtt.so` stating `global_timestamp: symbol not found`. According to the results of `objdump`, it was discovered that `global_timestamp` is defined in `main.c` but cannot be found in `libneuron-base.so`. Therefore,` global_timestamp` needs to be moved to `libneuron-base.so` for definition.