### PR TITLE
add custom mqtt schema ${dmp_values}

### DIFF
--- a/plugins/mqtt/schema.c
+++ b/plugins/mqtt/schema.c
@@ -44,6 +44,8 @@ static int mqtt_schema_parse(json_t *root, mqtt_schema_vt_t **vts,
                 vt->vt = MQTT_SCHEMA_TAG_ERROR_VALUES;
             } else if (strcmp(str_val, "${tag_errors}") == 0) {
                 vt->vt = MQTT_SCHEMA_TAG_ERRORS;
+            } else if (strcmp(str_val, "${dmp_values}") == 0) {
+                vt->vt = MQTT_SCHEMA_DMP_VALUES;
             } else {
                 if (str_val[0] == '$' && str_val[1] == '{' &&
                     str_val[strlen(str_val) - 1] == '}') {
@@ -184,6 +186,74 @@ static void *schema_encode(char *driver, char *group,
             }
 
             elem.t            = NEU_JSON_OBJECT;
+            elem.v.val_object = values_array;
+            break;
+        }
+        /* custom upload mod to dmp json format {"key":{"value":"123"}}*/
+        case MQTT_SCHEMA_DMP_VALUES: {
+            void *values_array = neu_json_encode_new();
+
+            neu_json_read_resp_tag_t *p_tag = tags->tags;
+
+            for (int j = 0; j < tags->n_tag; j++) {
+                neu_json_elem_t tag_elems[1 + NEU_TAG_META_SIZE] = { 0 };
+
+                if (p_tag->error == 0) {
+                    void *value_object = neu_json_encode_new();
+                    neu_json_elem_t value_elem = { 0 };
+                    value_elem.name = "value";
+                    value_elem.t = NEU_JSON_STR;
+
+                    char *value_str = NULL;
+                    switch (p_tag->t) {
+                        case NEU_JSON_INT:
+                            value_str = malloc(32);
+                            if (value_str != NULL) {
+                                snprintf(value_str, 32, "%ld", (long)p_tag->value.val_int);
+                            }
+                            break;
+                        case NEU_JSON_DOUBLE:
+                            value_str = malloc(64);
+                            if (value_str != NULL) {
+                                snprintf(value_str, 64, "%lf", p_tag->value.val_double);
+                            }
+                            break;
+                        case NEU_JSON_FLOAT:
+                            value_str = malloc(64);
+                            if (value_str != NULL) {
+                                snprintf(value_str, 64, "%f", p_tag->value.val_float);
+                            }
+                            break;
+                        case NEU_JSON_BOOL:
+                            value_str = malloc(6);
+                            if (value_str != NULL) {
+                                snprintf(value_str, 6, "%s", p_tag->value.val_bool ? "true" : "false");
+                            }
+                            break;
+                        case NEU_JSON_STR:
+                            value_str = strdup(p_tag->value.val_str);
+                            break;
+                        default:
+                            value_str = strdup("unknown");
+                            break;
+                    }
+                    value_elem.v.val_str = value_str;
+                    neu_json_encode_field(value_object, &value_elem, 1);
+                    free(value_str);
+                    tag_elems[0].name = p_tag->name;
+                    tag_elems[0].t = NEU_JSON_OBJECT;
+                    tag_elems[0].v.val_object = value_object;
+
+                    for (int k = 0; k < p_tag->n_meta; k++) {
+                        tag_elems[1 + k].name = p_tag->metas[k].name;
+                        tag_elems[1 + k].t = p_tag->metas[k].t;
+                        tag_elems[1 + k].v = p_tag->metas[k].value;
+                    }
+                    neu_json_encode_field(values_array, tag_elems, 1 + p_tag->n_meta);
+                }
+                p_tag++;
+            }
+            elem.t = NEU_JSON_OBJECT;
             elem.v.val_object = values_array;
             break;
         }

--- a/plugins/mqtt/schema.h
+++ b/plugins/mqtt/schema.h
@@ -43,6 +43,7 @@ typedef enum {
     MQTT_SCHEMA_TAG_ERROR_VALUES = 8,
     MQTT_SCHEMA_UD               = 9,
     MQTT_SCHEMA_OBJECT           = 10,
+    MQTT_SCHEMA_DMP_VALUES       = 11
 } mqtt_schema_vt_e;
 
 typedef struct mqtt_schema_vt mqtt_schema_vt_t;

--- a/tests/ut/mqtt_schema_test.cc
+++ b/tests/ut/mqtt_schema_test.cc
@@ -12,12 +12,12 @@ TEST(validate_success, schema)
     const char *schema =
         "{\"timestamp\":\"${timestamp}\",\"node\":\"${node}\",\"group\":\"${"
         "group}\",\"tags\":\"${tag_values}\",\"static\":\"${static_"
-        "tags}\",\"errors\":\"${tag_errors}\", \"xxxxx\":\"yyy\"}";
+        "tags}\",\"errors\":\"${tag_errors}\", \"dmp\":\"${dmp_values}\", \"xxxxx\":\"yyy\"}";
     mqtt_schema_vt_t *vts;
     size_t            n_vts;
     int               ret = mqtt_schema_validate(schema, &vts, &n_vts);
     EXPECT_EQ(ret, 0);
-    EXPECT_EQ(n_vts, 7);
+    EXPECT_EQ(n_vts, 8);
 
     EXPECT_STREQ(vts[0].name, "timestamp");
     EXPECT_EQ(vts[0].vt, MQTT_SCHEMA_TIMESTAMP);
@@ -37,9 +37,12 @@ TEST(validate_success, schema)
     EXPECT_STREQ(vts[5].name, "errors");
     EXPECT_EQ(vts[5].vt, MQTT_SCHEMA_TAG_ERRORS);
 
-    EXPECT_STREQ(vts[6].name, "xxxxx");
-    EXPECT_EQ(vts[6].vt, MQTT_SCHEMA_UD);
-    EXPECT_STREQ(vts[6].ud, "yyy");
+    EXPECT_STREQ(vts[6].name, "dmp");
+    EXPECT_EQ(vts[6].vt, MQTT_SCHEMA_DMP_VALUES);
+
+    EXPECT_STREQ(vts[7].name, "xxxxx");
+    EXPECT_EQ(vts[7].vt, MQTT_SCHEMA_UD);
+    EXPECT_STREQ(vts[7].ud, "yyy");
 
     free(vts);
 }


### PR DESCRIPTION
add add custom mqtt schema ${dmp_values}
example:
{ "id": "${timestamp}","version":"1.0","params": "${dmp_values}","method":"property.post"}

output:
