### PR TITLE
fix(connection): conn->param.params.tcp_server.ip and conn->tcp_serve…

### DIFF
--- a/src/connection/connection.c
+++ b/src/connection/connection.c
@@ -135,9 +135,9 @@ neu_conn_t *neu_conn_reconfig(neu_conn_t *conn, neu_conn_param_t *param)
 {
     pthread_mutex_lock(&conn->mtx);
 
+    conn_tcp_server_stop(conn);
     conn_disconnect(conn);
     conn_free_param(conn);
-    conn_tcp_server_stop(conn);
 
     conn_init_param(conn, param);
     conn_tcp_server_listen(conn);


### PR DESCRIPTION
modbus rtu plugin use tcp server mode, when reconfig will coredump
![image](https://github.com/user-attachments/assets/712cffa0-d766-48b3-87d8-8a36115130f4)
