### PR TITLE
fix: handle NULL json_str case to avoid undefined behavior

### DIFF
--- a/plugins/mqtt/mqtt_handle.c
+++ b/plugins/mqtt/mqtt_handle.c
@@ -1491,7 +1491,9 @@ int handle_trans_data(neu_plugin_t *            plugin,
                 plugin, trans_data, plugin->config.format,
                 plugin->config.schema_vts, plugin->config.n_schema_vt,
                 static_tags, n_satic_tag, &skip_none);
-            size = strlen(json_str);
+            if (json_str != NULL) {
+                size = strlen(json_str);
+            }
         }
         if (n_satic_tag > 0) {
             mqtt_static_free(static_tags, n_satic_tag);


### PR DESCRIPTION
fix: handle NULL json_str case to avoid undefined behavior